### PR TITLE
[#1] Add fix for safari/ff bug when able to write string into number …

### DIFF
--- a/src/components/FormItem.vue
+++ b/src/components/FormItem.vue
@@ -162,7 +162,9 @@ export default {
         focus() {
             this.$emit('focus');
         },
-        blur() {
+        blur(ev) {
+            ev.target.value = this.localValue;
+
             this.validate();
             this.$emit('blur');
         },


### PR DESCRIPTION
Should fix issue with safari and ff when able to write string into type number input and thus forcing v-model to return empty string which triggers removal ov our `form-item--filled` class.
This will thus show the label over the phantom text which wont be printed by v-model.